### PR TITLE
feat: improve github reader and UI enhancements

### DIFF
--- a/GITHUB_READER_FEATURE.md
+++ b/GITHUB_READER_FEATURE.md
@@ -1,0 +1,1042 @@
+# GitHub Repository Browser Feature
+
+## Overview
+
+The GitHub Repository Browser feature enables users to open, browse, and view files from GitHub repositories directly in Hotnote without requiring a local workspace. This read-only mode provides a seamless way to explore documentation, review code, and read markdown files from any public GitHub repository.
+
+## Key Features
+
+- **URL-based File Opening**: Open any GitHub file via URL parameter
+- **Full Repository Navigation**: Browse the complete directory structure of any GitHub repository
+- **Folder Navigation**: Click folders to navigate into directories, use '...' to go to parent directory
+- **Related Files Section**: View and navigate folders and files in the current directory
+- **README Discovery**: Automatically highlight and quick-access README files
+- **Read-Only Mode**: Safe viewing without risk of accidental modifications
+- **No Workspace Required**: Access files without local directory setup
+
+## User Stories
+
+### Story 1: Quick Documentation Review
+> As a developer, I want to quickly view a project's README from a GitHub link so that I can understand the project without cloning the repository.
+
+**Flow:**
+1. User receives link: `https://hotnote.io/?gitreader=https://raw.githubusercontent.com/user/repo/main/README.md`
+2. Hotnote opens with the README displayed in WYSIWYG mode
+3. File picker shows the repository structure
+4. User can browse other documentation files
+
+### Story 2: Code Exploration
+> As a code reviewer, I want to explore a repository's file structure so that I can understand the project organization.
+
+**Flow:**
+1. User opens any file from a GitHub repo
+2. Related Files section displays folders and files in the current directory
+3. Breadcrumb shows: `owner/repo@branch > folder > file.md`
+4. User clicks a folder in Related Files to navigate into it
+5. Breadcrumb updates to show new location: `owner/repo@branch > folder > subfolder`
+6. Related Files shows contents of the subfolder
+7. User clicks '...' to navigate back to parent directory
+8. Breadcrumb updates to reflect parent path
+9. User clicks different files to open and read them
+
+## Technical Architecture
+
+### Component Overview
+
+```
+┌─────────────────────────────────────────────────────────┐
+│                     app.js (Entry Point)                │
+│  - URL Parameter Detection                              │
+│  - GitHub Mode Initialization                           │
+└─────────────────────┬───────────────────────────────────┘
+                      │
+        ┌─────────────┴─────────────┐
+        │                           │
+┌───────▼──────────┐      ┌────────▼─────────┐
+│  GitHub Adapter  │      │   App State      │
+│                  │      │                  │
+│ - API Client     │◄─────┤ - isGitHubMode   │
+│ - URL Parsing    │      │ - isReadOnly     │
+│ - Rate Limiting  │      │ - githubRepo     │
+│ - Caching        │      └──────────────────┘
+└────────┬─────────┘
+         │
+┌────────▼─────────────────────────────────────┐
+│        Virtual File Handle Layer             │
+│  - GitHubFileHandle (wraps API responses)    │
+│  - Compatible with FileSystemHandle interface│
+└────────┬─────────────────────────────────────┘
+         │
+    ┌────┴────┐
+    │         │
+┌───▼────┐ ┌─▼──────────┐
+│File    │ │ Breadcrumb │
+│Picker  │ │ Navigation │
+│        │ │            │
+│- Tree  │ │- Repo Path │
+│- Search│ │- Click Nav │
+└────────┘ └────────────┘
+```
+
+### Core Modules
+
+#### 1. GitHub Adapter (`src/fs/github-adapter.js`)
+
+**Responsibilities:**
+- Parse GitHub URLs (raw.githubusercontent.com, github.com)
+- Interact with GitHub Contents API
+- Implement rate limiting and caching
+- Provide virtual file handles
+
+**Key Methods:**
+```javascript
+class GitHubAdapter {
+  constructor(owner, repo, branch = 'main')
+
+  // Parse various GitHub URL formats
+  static parseURL(url) → { owner, repo, branch, path }
+
+  // List directory contents
+  async listDirectory(path) → Array<VirtualFileHandle>
+
+  // Fetch file content
+  async readFile(path) → string
+
+  // Get file metadata
+  async getMetadata(path) → { size, lastModified, sha }
+
+  // Check rate limit status
+  async getRateLimit() → { remaining, limit, reset }
+}
+```
+
+#### 2. Virtual File Handle (`src/fs/virtual-file-handle.js`)
+
+**Purpose:** Provide a compatible interface with FileSystemHandle for GitHub files
+
+```javascript
+class GitHubFileHandle {
+  constructor(owner, repo, branch, path, type, downloadUrl)
+
+  // Properties
+  name: string
+  kind: 'file' | 'directory'
+  path: string
+  downloadUrl: string
+  isRemote: true
+
+  // Methods
+  async getFile() → VirtualFile
+  async queryPermission() → 'granted' (read-only)
+}
+```
+
+#### 3. App State Extensions (`src/state/app-state.js`)
+
+**New State Properties:**
+```javascript
+{
+  // GitHub mode flag
+  isGitHubMode: boolean,
+
+  // Read-only mode (for all URL-loaded files)
+  isReadOnly: boolean,
+
+  // GitHub repository info
+  githubRepo: {
+    owner: string,
+    repo: string,
+    branch: string,
+    rootPath: string
+  },
+
+  // Current directory path being viewed in GitHub mode
+  githubCurrentPath: string,
+
+  // GitHub adapter instance
+  githubAdapter: GitHubAdapter | null,
+
+  // Remote source URL
+  remoteSource: string | null
+}
+```
+
+### URL Parameter Specification
+
+#### Supported URL Formats
+
+**1. Raw GitHub Content URLs**
+```
+https://hotnote.io/?gitreader=https://raw.githubusercontent.com/OWNER/REPO/BRANCH/PATH
+```
+
+Example:
+```
+https://hotnote.io/?gitreader=https://raw.githubusercontent.com/zombar/hotnote.io/main/README.md
+```
+
+**2. GitHub Blob URLs (Optional/Future)**
+```
+https://hotnote.io/?gitreader=https://github.com/OWNER/REPO/blob/BRANCH/PATH
+```
+
+Example:
+```
+https://hotnote.io/?gitreader=https://github.com/zombar/hotnote.io/blob/main/README.md
+```
+
+#### URL Parsing Logic
+
+```javascript
+function parseGitHubURL(url) {
+  // Raw GitHub pattern
+  const rawPattern = /^https:\/\/raw\.githubusercontent\.com\/([^\/]+)\/([^\/]+)\/([^\/]+)\/(.+)$/;
+
+  // GitHub blob pattern (optional)
+  const blobPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+
+  const rawMatch = url.match(rawPattern);
+  if (rawMatch) {
+    return {
+      owner: rawMatch[1],
+      repo: rawMatch[2],
+      branch: rawMatch[3],
+      path: rawMatch[4]
+    };
+  }
+
+  const blobMatch = url.match(blobPattern);
+  if (blobMatch) {
+    return {
+      owner: blobMatch[1],
+      repo: blobMatch[2],
+      branch: blobMatch[3],
+      path: blobMatch[4]
+    };
+  }
+
+  throw new Error('Invalid GitHub URL format');
+}
+```
+
+## File Browsing & Navigation
+
+### Directory Listing
+
+**GitHub API Endpoint:**
+```
+GET https://api.github.com/repos/{owner}/{repo}/contents/{path}?ref={branch}
+```
+
+**Response Processing:**
+```javascript
+async function loadDirectory(path) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${path}?ref=${branch}`;
+  const response = await fetch(url);
+  const items = await response.json();
+
+  return items.map(item => ({
+    name: item.name,
+    type: item.type, // 'file' | 'dir'
+    size: item.size,
+    downloadUrl: item.download_url,
+    path: item.path
+  }));
+}
+```
+
+### File Picker Integration
+
+**Modifications to `src/ui/file-picker.js`:**
+
+1. **Detect GitHub Mode:**
+```javascript
+const isGitHub = appState.isGitHubMode;
+const adapter = isGitHub ? appState.githubAdapter : FileSystemAdapter;
+```
+
+2. **Disable Write Operations:**
+```javascript
+if (appState.isReadOnly) {
+  // Hide delete button
+  deleteBtn.style.display = 'none';
+
+  // Hide create file/folder buttons
+  createFileBtn.style.display = 'none';
+  createFolderBtn.style.display = 'none';
+}
+```
+
+3. **Add Loading States:**
+```javascript
+async function loadDirectoryWithLoading(path) {
+  showLoadingSpinner();
+  try {
+    const items = await adapter.listDirectory(path);
+    renderFileList(items);
+  } catch (error) {
+    showError('Failed to load directory: ' + error.message);
+  } finally {
+    hideLoadingSpinner();
+  }
+}
+```
+
+### Related Files Section (GitHub Mode)
+
+**Overview:**
+When in GitHub reader mode, the "Related Files" section (file picker) must display folder navigation similar to local mode, allowing users to browse the repository structure.
+
+**Required Elements:**
+
+1. **Parent Directory Row ('...')**
+   - Show a `...` row at the top of the file list to navigate to parent directory
+   - Only show when not at repository root
+   - Clicking navigates up one level in the directory hierarchy
+
+2. **Folder Rows**
+   - Display all directories in the current path
+   - Show folder icon (📁) to distinguish from files
+   - Clicking a folder navigates into that directory and loads its contents
+   - Sort folders before files (alphabetically within each group)
+
+3. **File Rows**
+   - Display all files in the current directory
+   - Show file icon based on extension
+   - Clicking opens the file in the editor
+
+**Implementation:**
+```javascript
+async function renderRelatedFilesForGitHub(currentPath) {
+  const items = await appState.githubAdapter.listDirectory(currentPath);
+  const relatedFilesList = document.getElementById('related-files-list');
+
+  relatedFilesList.innerHTML = '';
+
+  // Add parent directory navigation if not at root
+  if (currentPath !== '' && currentPath !== '/') {
+    const parentRow = document.createElement('div');
+    parentRow.className = 'file-row parent-dir';
+    parentRow.innerHTML = `
+      <span class="file-icon">📁</span>
+      <span class="file-name">...</span>
+    `;
+    parentRow.addEventListener('click', () => {
+      const parentPath = currentPath.split('/').slice(0, -1).join('/');
+      navigateToDirectory(parentPath);
+    });
+    relatedFilesList.appendChild(parentRow);
+  }
+
+  // Separate and sort folders and files
+  const folders = items.filter(item => item.type === 'dir');
+  const files = items.filter(item => item.type === 'file');
+
+  // Render folders first
+  folders.forEach(folder => {
+    const folderRow = document.createElement('div');
+    folderRow.className = 'file-row folder';
+    folderRow.innerHTML = `
+      <span class="file-icon">📁</span>
+      <span class="file-name">${folder.name}</span>
+    `;
+    folderRow.addEventListener('click', () => {
+      navigateToDirectory(folder.path);
+    });
+    relatedFilesList.appendChild(folderRow);
+  });
+
+  // Render files
+  files.forEach(file => {
+    const fileRow = document.createElement('div');
+    fileRow.className = 'file-row';
+    fileRow.innerHTML = `
+      <span class="file-icon">${getFileIcon(file.name)}</span>
+      <span class="file-name">${file.name}</span>
+    `;
+    fileRow.addEventListener('click', () => {
+      openGitHubFile(file.path);
+    });
+    relatedFilesList.appendChild(fileRow);
+  });
+}
+
+async function navigateToDirectory(path) {
+  // Update current path state
+  appState.githubCurrentPath = path;
+
+  // Update breadcrumb to reflect new location
+  updateBreadcrumbForGitHub(path);
+
+  // Re-render file list with new directory contents
+  await renderRelatedFilesForGitHub(path);
+}
+
+// Example usage when clicking a folder:
+// User clicks "src" folder → navigateToDirectory("src")
+//   → Breadcrumb updates to "owner/repo@branch > src"
+//   → Related Files shows contents of src folder
+```
+
+**Visual Hierarchy:**
+```
+Related Files
+├── ... (parent directory - only if not at root)
+├── 📁 docs (folder)
+├── 📁 src (folder)
+├── 📖 README.md (file - special icon for README)
+├── 📄 package.json (file)
+└── 📄 index.html (file)
+```
+
+**State Management:**
+```javascript
+// Add to app-state.js
+{
+  // ... existing GitHub state
+  githubCurrentPath: string,  // Current directory path being viewed
+}
+```
+
+**Integration with Breadcrumbs:**
+The Related Files section and breadcrumb navigation are tightly integrated:
+- Every folder navigation updates both the Related Files list AND the breadcrumb
+- Clicking a breadcrumb segment navigates to that folder and updates Related Files
+- Both components always stay synchronized via `appState.githubCurrentPath`
+
+### README Discovery
+
+**Auto-Detection Logic:**
+```javascript
+function highlightREADME(items) {
+  return items.map(item => {
+    if (item.name.toLowerCase() === 'readme.md') {
+      item.isREADME = true;
+      item.icon = '📖'; // Special icon
+      item.priority = 1; // Sort to top
+    }
+    return item;
+  });
+}
+```
+
+**Quick README Access:**
+- Add "View README" button when browsing directories
+- Auto-open README when entering a new folder (optional)
+- Highlight README files with special icon/styling
+
+### Breadcrumb Navigation
+
+**Dynamic Updates:**
+The breadcrumb must update in real-time when navigating between folders in GitHub mode. This provides users with clear context about their current location in the repository.
+
+**Format for GitHub Repos:**
+```
+owner/repo@branch > folder1 > folder2 > file.md
+```
+
+**Behavior:**
+- When user clicks a folder: breadcrumb updates to show new path
+- When user clicks '...' (parent): breadcrumb updates to show parent path
+- When user clicks a file: breadcrumb updates to show full file path
+- Each breadcrumb segment is clickable to navigate to that level
+
+**Implementation:**
+```javascript
+function updateBreadcrumbForGitHub(currentPath) {
+  const { owner, repo, branch } = appState.githubRepo;
+  const pathParts = currentPath.split('/').filter(Boolean);
+
+  breadcrumb.innerHTML = `
+    <span class="repo-root clickable" data-path="">${owner}/${repo}@${branch}</span>
+    ${pathParts.map((part, idx) => `
+      <span class="separator">›</span>
+      <span class="path-part clickable" data-path="${pathParts.slice(0, idx + 1).join('/')}">${part}</span>
+    `).join('')}
+  `;
+
+  // Make breadcrumb parts clickable for navigation
+  breadcrumb.querySelectorAll('.clickable').forEach(el => {
+    el.addEventListener('click', () => {
+      const path = el.getAttribute('data-path');
+      navigateToDirectory(path);
+    });
+  });
+}
+```
+
+**Examples:**
+```
+# At repository root
+zombar/hotnote@main
+
+# In docs folder
+zombar/hotnote@main > docs
+
+# In nested folder
+zombar/hotnote@main > src > components
+
+# Viewing a file
+zombar/hotnote@main > src > index.js
+```
+
+## Read-Only Mode
+
+### Visual Indicators
+
+**1. Header Badge:**
+```html
+<div class="readonly-badge">
+  🔒 Read-Only (GitHub)
+</div>
+```
+
+**2. Status Bar:**
+```html
+<div class="status-bar">
+  Source: github.com/owner/repo/blob/branch/file.md
+</div>
+```
+
+**3. Disabled UI Elements:**
+- Save button (grayed out)
+- Autosave indicator (hidden)
+- File deletion (hidden)
+- File creation (hidden)
+
+### Editor Configuration
+
+**CodeMirror Read-Only:**
+```javascript
+if (appState.isReadOnly) {
+  extensions.push(EditorState.readOnly.of(true));
+  extensions.push(EditorView.editable.of(false));
+}
+```
+
+**Milkdown Read-Only:**
+```javascript
+if (appState.isReadOnly) {
+  editor.use(readonly.plugin());
+}
+```
+
+### User Feedback
+
+**Attempt to Save:**
+```javascript
+function handleSave() {
+  if (appState.isReadOnly) {
+    showNotification('This file is read-only. Open a local workspace to make edits.', 'warning');
+    return;
+  }
+  // ... normal save logic
+}
+```
+
+## GitHub API Integration
+
+### Rate Limiting
+
+**Limits:**
+- Unauthenticated: 60 requests/hour
+- Authenticated: 5,000 requests/hour
+
+**Rate Limit Tracking:**
+```javascript
+class RateLimiter {
+  constructor() {
+    this.remaining = 60;
+    this.limit = 60;
+    this.reset = null;
+  }
+
+  updateFromHeaders(headers) {
+    this.remaining = parseInt(headers.get('X-RateLimit-Remaining'));
+    this.limit = parseInt(headers.get('X-RateLimit-Limit'));
+    this.reset = new Date(parseInt(headers.get('X-RateLimit-Reset')) * 1000);
+  }
+
+  async waitIfNeeded() {
+    if (this.remaining <= 5) {
+      const waitTime = this.reset - Date.now();
+      if (waitTime > 0) {
+        showNotification(`Rate limit low. Waiting ${Math.ceil(waitTime / 60000)} minutes...`);
+        await sleep(waitTime);
+      }
+    }
+  }
+}
+```
+
+**Display in UI:**
+```html
+<div class="rate-limit-indicator">
+  API Calls: 45/60 remaining
+</div>
+```
+
+### Caching Strategy
+
+**1. Response Cache:**
+```javascript
+class APICache {
+  constructor(ttl = 5 * 60 * 1000) { // 5 minutes
+    this.cache = new Map();
+    this.ttl = ttl;
+  }
+
+  set(key, value) {
+    this.cache.set(key, {
+      value,
+      timestamp: Date.now()
+    });
+  }
+
+  get(key) {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+
+    if (Date.now() - entry.timestamp > this.ttl) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.value;
+  }
+}
+```
+
+**2. Cache Keys:**
+```javascript
+function getCacheKey(owner, repo, branch, path) {
+  return `${owner}/${repo}@${branch}:${path}`;
+}
+```
+
+**3. Invalidation:**
+- Time-based (5 minute TTL)
+- Manual refresh button
+- Branch switch clears cache
+
+### Error Handling
+
+**1. Network Errors:**
+```javascript
+async function fetchWithRetry(url, retries = 3) {
+  for (let i = 0; i < retries; i++) {
+    try {
+      const response = await fetch(url);
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+      return response;
+    } catch (error) {
+      if (i === retries - 1) throw error;
+      await sleep(Math.pow(2, i) * 1000); // Exponential backoff
+    }
+  }
+}
+```
+
+**2. 404 Not Found:**
+```javascript
+if (response.status === 404) {
+  showError('File not found in repository. It may have been moved or deleted.');
+}
+```
+
+**3. Rate Limit Exceeded:**
+```javascript
+if (response.status === 403 && response.headers.get('X-RateLimit-Remaining') === '0') {
+  const reset = new Date(parseInt(response.headers.get('X-RateLimit-Reset')) * 1000);
+  showError(`GitHub API rate limit exceeded. Resets at ${reset.toLocaleTimeString()}`);
+}
+```
+
+**4. CORS Errors:**
+```javascript
+catch (error) {
+  if (error.name === 'TypeError' && error.message.includes('CORS')) {
+    showError('Unable to access this file due to CORS restrictions.');
+  }
+}
+```
+
+## Security & Privacy
+
+### URL Validation
+
+**Whitelist Approach:**
+```javascript
+function validateGitHubURL(url) {
+  const allowedDomains = [
+    'raw.githubusercontent.com',
+    'github.com'
+  ];
+
+  try {
+    const parsed = new URL(url);
+    if (!allowedDomains.includes(parsed.hostname)) {
+      throw new Error('Only GitHub URLs are allowed');
+    }
+    return true;
+  } catch (error) {
+    throw new Error('Invalid URL format');
+  }
+}
+```
+
+### Content Safety
+
+**1. File Size Limits:**
+```javascript
+const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10MB
+
+async function fetchFileContent(url) {
+  const response = await fetch(url);
+  const contentLength = response.headers.get('Content-Length');
+
+  if (contentLength && parseInt(contentLength) > MAX_FILE_SIZE) {
+    throw new Error('File too large to display (max 10MB)');
+  }
+
+  return await response.text();
+}
+```
+
+**2. Content Type Validation:**
+```javascript
+function isSafeContentType(contentType) {
+  const safeTypes = [
+    'text/plain',
+    'text/markdown',
+    'application/json',
+    'text/javascript',
+    // ... other text-based types
+  ];
+
+  return safeTypes.some(type => contentType.includes(type));
+}
+```
+
+### CORS Handling
+
+**GitHub Raw Content:**
+- `raw.githubusercontent.com` allows CORS for all origins
+- GitHub API endpoint `api.github.com` requires proper CORS headers
+
+**No Proxy Needed:**
+All GitHub raw content URLs are CORS-enabled by default.
+
+### Privacy Considerations
+
+**1. No Authentication by Default:**
+- Only public repositories accessible
+- No personal access tokens stored
+- No OAuth flow required
+
+**2. No Tracking:**
+- File access not logged
+- User browsing history not collected
+- GitHub API calls use standard rate limits
+
+**3. Local-Only State:**
+- No server-side storage
+- No user data transmitted
+- All operations client-side
+
+## Browser Compatibility
+
+### Supported Browsers
+
+| Browser | Version | Support Level |
+|---------|---------|--------------|
+| Chrome | 90+ | ✅ Full Support |
+| Edge | 90+ | ✅ Full Support |
+| Firefox | 88+ | ✅ Full Support |
+| Safari | 14+ | ✅ Full Support |
+| Opera | 76+ | ✅ Full Support |
+
+### Required APIs
+
+**1. Fetch API:**
+- Supported: All modern browsers
+- Fallback: None needed
+
+**2. URL API:**
+- Supported: All modern browsers
+- Fallback: None needed
+
+**3. URLSearchParams:**
+- Supported: All modern browsers
+- Fallback: Manual parsing for IE11
+
+**4. ES6+ Features:**
+- Classes, async/await, arrow functions
+- Transpilation handled by build process
+
+### Polyfills
+
+None required for target browsers (modern evergreen browsers only).
+
+## Future Enhancements
+
+### Phase 2: Authentication
+
+**GitHub Personal Access Token:**
+```javascript
+class AuthenticatedGitHubAdapter extends GitHubAdapter {
+  constructor(owner, repo, branch, token) {
+    super(owner, repo, branch);
+    this.token = token;
+  }
+
+  async fetch(url) {
+    return fetch(url, {
+      headers: {
+        'Authorization': `token ${this.token}`
+      }
+    });
+  }
+}
+```
+
+**Benefits:**
+- Access private repositories
+- Increased rate limit (5,000 req/hour)
+- Access to protected branches
+
+**UI:**
+- Settings panel for token input
+- Secure storage in localStorage (encrypted)
+- Token validation
+
+### Phase 3: Local File Opening (`?localdir`)
+
+**File Handling API Investigation:**
+
+**Manifest Declaration:**
+```json
+{
+  "file_handlers": [
+    {
+      "action": "/",
+      "accept": {
+        "text/markdown": [".md"],
+        "text/plain": [".txt"]
+      }
+    }
+  ]
+}
+```
+
+**Launch Handler:**
+```javascript
+if ('launchQueue' in window) {
+  launchQueue.setConsumer(async (launchParams) => {
+    if (launchParams.files && launchParams.files.length > 0) {
+      const fileHandle = launchParams.files[0];
+      await openFileWithoutWorkspace(fileHandle);
+    }
+  });
+}
+```
+
+**Limitations:**
+- Chrome 102+, Edge 102+ only
+- Requires PWA installation
+- User must set Hotnote as default handler
+
+**Alternative: File Picker API**
+```javascript
+async function openLocalFileReadOnly() {
+  const [fileHandle] = await window.showOpenFilePicker({
+    types: [
+      {
+        description: 'Markdown Files',
+        accept: { 'text/markdown': ['.md'] }
+      }
+    ]
+  });
+
+  const file = await fileHandle.getFile();
+  await openInReadOnlyMode(file);
+}
+```
+
+### Phase 4: Branch/Tag Selector
+
+**UI Component:**
+```html
+<select id="branch-selector" class="branch-select">
+  <option value="main">main</option>
+  <option value="develop">develop</option>
+  <option value="v1.0.0">v1.0.0 (tag)</option>
+</select>
+```
+
+**API Integration:**
+```javascript
+async function listBranches(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/branches`;
+  const response = await fetch(url);
+  return await response.json();
+}
+
+async function listTags(owner, repo) {
+  const url = `https://api.github.com/repos/${owner}/${repo}/tags`;
+  const response = await fetch(url);
+  return await response.json();
+}
+```
+
+### Phase 5: Advanced Features
+
+**1. Search Across Repository:**
+```javascript
+async function searchCode(owner, repo, query) {
+  const url = `https://api.github.com/search/code?q=${query}+repo:${owner}/${repo}`;
+  const response = await fetch(url);
+  return await response.json();
+}
+```
+
+**2. Git Blame Integration:**
+```javascript
+async function getBlameInfo(owner, repo, path, lineNumber) {
+  // Use GitHub GraphQL API
+  const query = `
+    query {
+      repository(owner: "${owner}", name: "${repo}") {
+        object(expression: "HEAD:${path}") {
+          ... on Blob {
+            blame {
+              ranges {
+                commit {
+                  author { name }
+                  message
+                  committedDate
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  `;
+  // Process and display blame info
+}
+```
+
+**3. Markdown Link Resolution:**
+- Relative links to other markdown files
+- Click to navigate between docs
+- Image loading from repository
+
+**4. Offline Support:**
+- Service Worker caching
+- IndexedDB for file content
+- Offline indicator
+
+## Implementation Phases
+
+### Phase 1: Foundation (Week 1)
+**Goal:** Basic GitHub file opening
+
+**Tasks:**
+- [ ] Create `GitHubAdapter` class
+- [ ] Implement URL parsing
+- [ ] Add GitHub mode to app state
+- [ ] Basic API integration
+- [ ] Read-only mode implementation
+- [ ] Simple error handling
+
+**Deliverable:** Single file opening from GitHub URL
+
+### Phase 2: Navigation (Week 2)
+**Goal:** Full repository browsing
+
+**Tasks:**
+- [ ] Integrate with file picker
+- [ ] Directory listing via API
+- [ ] Related Files section with folder rows
+- [ ] Parent directory ('...') navigation row
+- [ ] Breadcrumb updates on folder navigation (synchronized with Related Files)
+- [ ] Clickable breadcrumb segments for navigation
+- [ ] README discovery
+- [ ] Folder click-to-navigate functionality
+- [ ] Loading states
+
+**Deliverable:** Complete repository navigation with synchronized breadcrumb and Related Files
+
+### Phase 3: Polish (Week 3)
+**Goal:** Production-ready experience
+
+**Tasks:**
+- [ ] Rate limiting UI
+- [ ] Comprehensive error handling
+- [ ] Caching implementation
+- [ ] Visual indicators (read-only badge)
+- [ ] Performance optimization
+
+**Deliverable:** Production-ready feature
+
+### Phase 4: Documentation & Testing (Week 4)
+**Goal:** Quality assurance
+
+**Tasks:**
+- [ ] Unit tests for GitHub adapter
+- [ ] Integration tests for file picker
+- [ ] User documentation
+- [ ] Developer documentation
+- [ ] Performance testing
+- [ ] Security audit
+
+**Deliverable:** Fully tested and documented feature
+
+## Success Metrics
+
+### Performance Metrics
+- Initial file load: < 2 seconds
+- Directory listing: < 1 second
+- File navigation: < 500ms
+- Cache hit rate: > 80%
+
+### User Experience Metrics
+- Clear read-only indicators
+- Intuitive navigation
+- Helpful error messages
+- Responsive UI (no blocking)
+
+### Technical Metrics
+- API call efficiency (minimize redundant calls)
+- Memory usage (< 50MB for typical repos)
+- Rate limit utilization (< 50% for normal browsing)
+
+## Risks & Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Rate limit exceeded | High | Implement caching, show warnings at 80% |
+| Large repositories | Medium | Lazy loading, virtual scrolling |
+| Network failures | Medium | Retry logic, offline messaging |
+| CORS issues | Low | Use raw.githubusercontent.com (CORS-enabled) |
+| Security vulnerabilities | High | URL validation, content type checking |
+
+## Conclusion
+
+The GitHub Repository Browser feature transforms Hotnote into a versatile tool for exploring and viewing code repositories without local setup. By leveraging GitHub's public APIs and implementing a robust read-only mode, users can seamlessly access documentation, review code, and navigate project structures directly from their browser.
+
+**Key Benefits:**
+- Zero-friction access to GitHub content
+- No local workspace setup required
+- Safe read-only browsing
+- Full repository navigation
+- WYSIWYG markdown viewing
+
+**Next Steps:**
+1. Review and approve this feature specification
+2. Begin Phase 1 implementation
+3. Iterate based on user feedback
+4. Expand to advanced features in later phases

--- a/notes.md
+++ b/notes.md
@@ -1,5 +1,9 @@
 ## TODO
 
+* "made in Wales 🏴󠁧󠁢󠁷󠁬󠁳󠁿" 
+
+* register Hotnote as a handler for .md files
+
 * fix clicking on links
 
 * center the breadcrumbs on the navbar
@@ -10,7 +14,9 @@
 
 * When clicking a breadcrumb with the filepicker closed the breadcrumbs bar should be updated with the new location -> the filename text should be cleared and caret shown -> the file picker should be shown. When clicking a breadcrumb with the file picker open should: update the breadcrumb to the new location -> the filename should still be cleared and caret showing -> the file picker should be updated to the new location.
 
-* is the reload button broken for the new version popup?
+* <br />
+
+  is the reload button broken for the new version popup?
 
 * need to replace intellisense functionality somehow (1B local inferencing?)
 
@@ -31,10 +37,6 @@
 * should be able to open a file / folder using the path params (with the pop up open file dialog box)
 
 * fix links in the richtext editor (cmd + click to open)
-
-* Find replace function looses editor focus \[HIGH]
-
-* Text should be saved after typing so that it is retrieved asap by other windows looking at the same doc
 
 * Navbar animation is inconsistent, only plays on load
 

--- a/src/editors/editor-manager.js
+++ b/src/editors/editor-manager.js
@@ -6,11 +6,18 @@ import { SourceView } from './source-view.js';
  * Only one editor is active at a time, eliminating position sync issues
  */
 export class EditorManager {
-  constructor(container, initialMode = 'wysiwyg', initialContent = '', onChange = null) {
+  constructor(
+    container,
+    initialMode = 'wysiwyg',
+    initialContent = '',
+    onChange = null,
+    readOnly = false
+  ) {
     this.container = container;
     this.currentMode = initialMode;
     this.currentEditor = null;
     this.onChangeCallback = onChange;
+    this.readOnly = readOnly;
 
     // Initialize the first editor
     this.initPromise = this.init(initialMode, initialContent);
@@ -18,9 +25,19 @@ export class EditorManager {
 
   async init(mode, content) {
     if (mode === 'source') {
-      this.currentEditor = new SourceView(this.container, content, this.onChangeCallback);
+      this.currentEditor = new SourceView(
+        this.container,
+        content,
+        this.onChangeCallback,
+        this.readOnly
+      );
     } else {
-      this.currentEditor = new WYSIWYGView(this.container, content, this.onChangeCallback);
+      this.currentEditor = new WYSIWYGView(
+        this.container,
+        content,
+        this.onChangeCallback,
+        this.readOnly
+      );
       await this.currentEditor.ready();
     }
     return this.currentEditor;
@@ -58,9 +75,19 @@ export class EditorManager {
 
     // 3. Create new editor
     if (newMode === 'source') {
-      this.currentEditor = new SourceView(this.container, state.content, this.onChangeCallback);
+      this.currentEditor = new SourceView(
+        this.container,
+        state.content,
+        this.onChangeCallback,
+        this.readOnly
+      );
     } else {
-      this.currentEditor = new WYSIWYGView(this.container, state.content, this.onChangeCallback);
+      this.currentEditor = new WYSIWYGView(
+        this.container,
+        state.content,
+        this.onChangeCallback,
+        this.readOnly
+      );
       await this.currentEditor.ready();
     }
 

--- a/src/fs/github-adapter.js
+++ b/src/fs/github-adapter.js
@@ -1,0 +1,115 @@
+/**
+ * GitHubAdapter - Provides read-only access to GitHub repository files
+ * via the GitHub API and raw content URLs.
+ */
+export class GitHubAdapter {
+  constructor(owner, repo, branch = 'main') {
+    this.owner = owner;
+    this.repo = repo;
+    this.branch = branch;
+  }
+
+  /**
+   * Parse a GitHub URL and extract repository information
+   * @param {string} url - GitHub URL (raw.githubusercontent.com or github.com/blob)
+   * @returns {{owner: string, repo: string, branch: string, path: string}}
+   * @throws {Error} If URL format is invalid
+   */
+  static parseURL(url) {
+    // Pattern for raw.githubusercontent.com URLs
+    const rawPattern =
+      /^https:\/\/raw\.githubusercontent\.com\/([^\/]+)\/([^\/]+)\/([^\/]+)\/(.+)$/;
+
+    // Pattern for github.com blob URLs
+    const blobPattern = /^https:\/\/github\.com\/([^\/]+)\/([^\/]+)\/blob\/([^\/]+)\/(.+)$/;
+
+    const rawMatch = url.match(rawPattern);
+    if (rawMatch) {
+      return {
+        owner: rawMatch[1],
+        repo: rawMatch[2],
+        branch: rawMatch[3],
+        path: rawMatch[4],
+      };
+    }
+
+    const blobMatch = url.match(blobPattern);
+    if (blobMatch) {
+      return {
+        owner: blobMatch[1],
+        repo: blobMatch[2],
+        branch: blobMatch[3],
+        path: blobMatch[4],
+      };
+    }
+
+    throw new Error('Invalid GitHub URL format');
+  }
+
+  /**
+   * Read file content from GitHub
+   * @param {string} path - File path within the repository
+   * @returns {Promise<string>} File content
+   * @throws {Error} If file cannot be read
+   */
+  async readFile(path) {
+    const url = `https://raw.githubusercontent.com/${this.owner}/${this.repo}/${this.branch}/${path}`;
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return await response.text();
+  }
+
+  /**
+   * List directory contents using GitHub API
+   * @param {string} path - Directory path (empty string for root)
+   * @returns {Promise<Array<{name: string, type: 'file'|'dir', size: number, path: string, downloadUrl: string}>>}
+   * @throws {Error} If directory cannot be listed
+   */
+  async listDirectory(path) {
+    const url = `https://api.github.com/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`;
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const items = await response.json();
+
+    return items.map((item) => ({
+      name: item.name,
+      type: item.type, // 'file' or 'dir'
+      size: item.size,
+      path: item.path,
+      downloadUrl: item.download_url,
+    }));
+  }
+
+  /**
+   * Get file metadata from GitHub API
+   * @param {string} path - File path within the repository
+   * @returns {Promise<{size: number, sha: string}>} File metadata
+   * @throws {Error} If metadata cannot be retrieved
+   */
+  async getMetadata(path) {
+    const url = `https://api.github.com/repos/${this.owner}/${this.repo}/contents/${path}?ref=${this.branch}`;
+
+    const response = await fetch(url);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    const data = await response.json();
+
+    return {
+      size: data.size,
+      sha: data.sha,
+    };
+  }
+}

--- a/src/state/app-state.js
+++ b/src/state/app-state.js
@@ -38,6 +38,13 @@ class AppState {
     this.isRestoringSession = false; // Track if we're currently restoring from session
     this.lastRestorationTime = 0; // Track when we last restored state to prevent premature saves
 
+    // GitHub mode state
+    this.isGitHubMode = false; // Flag indicating GitHub reader mode
+    this.isReadOnly = false; // Flag indicating read-only mode (for GitHub and other remote files)
+    this.githubRepo = null; // GitHub repository info: {owner, repo, branch, path}
+    this.githubAdapter = null; // GitHubAdapter instance for API calls
+    this.remoteSource = null; // Remote source URL for the current file
+
     // Focus management
     this.focusManager = new FocusManager();
   }
@@ -85,6 +92,26 @@ class AppState {
 
   getFocusManager() {
     return this.focusManager;
+  }
+
+  getGitHubMode() {
+    return this.isGitHubMode;
+  }
+
+  getReadOnly() {
+    return this.isReadOnly;
+  }
+
+  getGitHubRepo() {
+    return this.githubRepo;
+  }
+
+  getGitHubAdapter() {
+    return this.githubAdapter;
+  }
+
+  getRemoteSource() {
+    return this.remoteSource;
   }
 
   // Setters
@@ -148,6 +175,26 @@ class AppState {
     this.lastRestorationTime = time;
   }
 
+  setGitHubMode(value) {
+    this.isGitHubMode = value;
+  }
+
+  setReadOnly(value) {
+    this.isReadOnly = value;
+  }
+
+  setGitHubRepo(repoInfo) {
+    this.githubRepo = repoInfo;
+  }
+
+  setGitHubAdapter(adapter) {
+    this.githubAdapter = adapter;
+  }
+
+  setRemoteSource(url) {
+    this.remoteSource = url;
+  }
+
   // Navigation history methods
   addToNavigationHistory(entry) {
     this.navigationHistory.push(entry);
@@ -186,6 +233,19 @@ class AppState {
     this.autosaveInterval = null;
     this.isRestoringSession = false;
     this.lastRestorationTime = 0;
+    this.isGitHubMode = false;
+    this.isReadOnly = false;
+    this.githubRepo = null;
+    this.githubAdapter = null;
+    this.remoteSource = null;
+  }
+
+  resetGitHubMode() {
+    this.isGitHubMode = false;
+    this.isReadOnly = false;
+    this.githubRepo = null;
+    this.githubAdapter = null;
+    this.remoteSource = null;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1599,7 +1599,7 @@ button:disabled:hover {
 
 /* Milkdown Editor Styles */
 .milkdown {
-  height: 100%;
+  min-height: 100%;
   background: var(--bg-primary);
   color: var(--text-primary);
   font-family:
@@ -1608,7 +1608,6 @@ button:disabled:hover {
   font-size: 1rem;
   line-height: 1.6;
   padding: 0 15% 0 1.5rem;
-  overflow: auto;
   display: flex;
   justify-content: flex-start; /* Left-align content, scrollbar at right edge */
 }
@@ -1625,15 +1624,14 @@ button:disabled:hover {
 }
 
 .milkdown .editor {
-  height: 100%;
+  min-height: 100%;
   outline: none;
 }
 
 .milkdown .ProseMirror {
   outline: none;
-  min-height: 100%;
-  padding: 4rem 0 7rem;
-  box-sizing: content-box;
+  min-height: 0;
+  padding: 2rem 0 7rem;
 }
 
 .milkdown .ProseMirror-focused {

--- a/tests/app-state-github.test.js
+++ b/tests/app-state-github.test.js
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { appState } from '../src/state/app-state.js';
+import { GitHubAdapter } from '../src/fs/github-adapter.js';
+
+describe('AppState - GitHub Mode', () => {
+  beforeEach(() => {
+    appState.resetAll();
+  });
+
+  describe('initialization', () => {
+    it('should initialize GitHub mode properties', () => {
+      expect(appState.isGitHubMode).toBe(false);
+      expect(appState.isReadOnly).toBe(false);
+      expect(appState.githubRepo).toBeNull();
+      expect(appState.githubAdapter).toBeNull();
+      expect(appState.remoteSource).toBeNull();
+    });
+  });
+
+  describe('GitHub mode setters and getters', () => {
+    it('should set and get isGitHubMode', () => {
+      appState.setGitHubMode(true);
+      expect(appState.isGitHubMode).toBe(true);
+      expect(appState.getGitHubMode()).toBe(true);
+    });
+
+    it('should set and get isReadOnly', () => {
+      appState.setReadOnly(true);
+      expect(appState.isReadOnly).toBe(true);
+      expect(appState.getReadOnly()).toBe(true);
+    });
+
+    it('should set and get githubRepo', () => {
+      const repoInfo = {
+        owner: 'zombar',
+        repo: 'hotnote',
+        branch: 'main',
+        path: 'README.md',
+      };
+      appState.setGitHubRepo(repoInfo);
+      expect(appState.githubRepo).toEqual(repoInfo);
+      expect(appState.getGitHubRepo()).toEqual(repoInfo);
+    });
+
+    it('should set and get githubAdapter', () => {
+      const adapter = new GitHubAdapter('zombar', 'hotnote', 'main');
+      appState.setGitHubAdapter(adapter);
+      expect(appState.githubAdapter).toBe(adapter);
+      expect(appState.getGitHubAdapter()).toBe(adapter);
+    });
+
+    it('should set and get remoteSource', () => {
+      const url = 'https://raw.githubusercontent.com/zombar/hotnote/main/README.md';
+      appState.setRemoteSource(url);
+      expect(appState.remoteSource).toBe(url);
+      expect(appState.getRemoteSource()).toBe(url);
+    });
+  });
+
+  describe('reset methods', () => {
+    beforeEach(() => {
+      // Set up GitHub mode
+      appState.setGitHubMode(true);
+      appState.setReadOnly(true);
+      appState.setGitHubRepo({ owner: 'test', repo: 'repo', branch: 'main', path: 'file.md' });
+      appState.setGitHubAdapter(new GitHubAdapter('test', 'repo', 'main'));
+      appState.setRemoteSource('https://example.com/file.md');
+    });
+
+    it('should reset GitHub mode properties with resetAll', () => {
+      appState.resetAll();
+
+      expect(appState.isGitHubMode).toBe(false);
+      expect(appState.isReadOnly).toBe(false);
+      expect(appState.githubRepo).toBeNull();
+      expect(appState.githubAdapter).toBeNull();
+      expect(appState.remoteSource).toBeNull();
+    });
+
+    it('should reset GitHub mode properties with resetGitHubMode', () => {
+      appState.resetGitHubMode();
+
+      expect(appState.isGitHubMode).toBe(false);
+      expect(appState.isReadOnly).toBe(false);
+      expect(appState.githubRepo).toBeNull();
+      expect(appState.githubAdapter).toBeNull();
+      expect(appState.remoteSource).toBeNull();
+    });
+  });
+
+  describe('GitHub mode workflow', () => {
+    it('should support enabling GitHub mode with all required state', () => {
+      const url = 'https://raw.githubusercontent.com/zombar/hotnote/main/README.md';
+      const repoInfo = GitHubAdapter.parseURL(url);
+      const adapter = new GitHubAdapter(repoInfo.owner, repoInfo.repo, repoInfo.branch);
+
+      appState.setGitHubMode(true);
+      appState.setReadOnly(true);
+      appState.setGitHubRepo(repoInfo);
+      appState.setGitHubAdapter(adapter);
+      appState.setRemoteSource(url);
+
+      expect(appState.isGitHubMode).toBe(true);
+      expect(appState.isReadOnly).toBe(true);
+      expect(appState.githubRepo).toEqual({
+        owner: 'zombar',
+        repo: 'hotnote',
+        branch: 'main',
+        path: 'README.md',
+      });
+      expect(appState.githubAdapter).toBe(adapter);
+      expect(appState.remoteSource).toBe(url);
+    });
+
+    it('should disable autosave when in read-only mode', () => {
+      appState.setAutosaveEnabled(true);
+      expect(appState.isAutosaveEnabled()).toBe(true);
+
+      appState.setReadOnly(true);
+      // In read-only mode, autosave should be disabled
+      // This will be handled by the editor initialization logic
+      expect(appState.isReadOnly).toBe(true);
+    });
+  });
+});

--- a/tests/e2e/github-reader-exit.spec.js
+++ b/tests/e2e/github-reader-exit.spec.js
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('GitHub Reader Mode - Exit Behavior', () => {
+  test('should restore UI and editor when opening workspace after GitHub reader', async ({
+    page,
+  }) => {
+    // 1. Load a GitHub file first
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Verify we're in GitHub mode (readonly)
+    const editorContainer = await page.locator('#editor');
+    const hasReadonly = await editorContainer.evaluate((el) => {
+      return (
+        el.classList.contains('readonly-editor') ||
+        el.querySelector('[contenteditable="false"]') !== null
+      );
+    });
+    expect(hasReadonly).toBe(true);
+
+    // Verify code/rich toggle button is hidden in GitHub mode
+    const richToggleBtn = await page.locator('#rich-toggle-btn');
+    const richToggleBtnVisible = await richToggleBtn.isVisible();
+    expect(richToggleBtnVisible).toBe(false);
+
+    // Verify file picker button is hidden in GitHub mode
+    const filePickerBtn = await page.locator('#file-picker-btn');
+    if ((await filePickerBtn.count()) > 0) {
+      const filePickerVisible = await filePickerBtn.isVisible();
+      expect(filePickerVisible).toBe(false);
+    }
+
+    // 2. Verify the "new" button is disabled in GitHub mode
+    const newBtn = await page.locator('#new-btn');
+    expect(await newBtn.isVisible()).toBe(true);
+    expect(await newBtn.isDisabled()).toBe(true);
+
+    // Mock the file picker dialog and exit GitHub mode programmatically
+    await page.evaluate(() => {
+      // Mock FileSystemAdapter.openDirectory to simulate user selecting a folder
+      window.FileSystemAdapter = {
+        openDirectory: async () => {
+          // Return a mock directory handle
+          return {
+            name: 'test-workspace',
+            kind: 'directory',
+            getDirectoryHandle: async () => null,
+            getFileHandle: async () => null,
+            values: async function* () {
+              // Empty directory
+            },
+          };
+        },
+        listDirectory: async () => [],
+        readFile: async () => '',
+        writeFile: async () => {},
+        saveFilePicker: async () => null,
+      };
+
+      // Directly call openFolder to exit GitHub mode (since button is disabled)
+      window.openFolder();
+    });
+
+    await page.waitForTimeout(1000);
+
+    // 3. Verify UI elements are restored
+    // Rich toggle button should be visible again (or at least not hidden)
+    const richToggleAfter = await page.locator('#rich-toggle-btn');
+    const richToggleStyleAfter = await richToggleAfter.evaluate((el) => el.style.display);
+    // Should not be 'none' anymore
+    expect(richToggleStyleAfter).not.toBe('none');
+
+    // File picker button should be visible again
+    const filePickerBtnAfter = await page.locator('#file-picker-btn');
+    if ((await filePickerBtnAfter.count()) > 0) {
+      const filePickerStyleAfter = await filePickerBtnAfter.evaluate((el) => el.style.display);
+      expect(filePickerStyleAfter).not.toBe('none');
+    }
+
+    // 4. Verify gitreader URL parameter is cleared
+    const currentUrl = page.url();
+    expect(currentUrl).not.toContain('gitreader=');
+
+    // 5. Verify GitHub mode state is cleared
+    const isGitHubMode = await page.evaluate(() => window.appState?.isGitHubMode);
+    expect(isGitHubMode).toBe(false);
+
+    const isReadOnly = await page.evaluate(() => window.appState?.isReadOnly);
+    expect(isReadOnly).toBe(false);
+  });
+
+  test('should allow editing after exiting GitHub reader mode', async ({ page }) => {
+    // Load GitHub file
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Try to type in readonly mode - should not work
+    await page.click('#editor');
+    await page.keyboard.type('Test text');
+    await page.waitForTimeout(500);
+
+    // Content should not change in readonly mode
+    const contentBefore = await page.textContent('#editor');
+    expect(contentBefore).not.toContain('Test text');
+
+    // Mock file system and exit GitHub mode
+    await page.evaluate(() => {
+      window.FileSystemAdapter = {
+        openDirectory: async () => ({
+          name: 'test-workspace',
+          kind: 'directory',
+          getDirectoryHandle: async () => null,
+          getFileHandle: async () => null,
+          values: async function* () {},
+        }),
+        listDirectory: async () => [],
+        readFile: async () => '',
+        writeFile: async () => {},
+        saveFilePicker: async () => null,
+      };
+
+      // Directly call openFolder to exit GitHub mode (since button is disabled)
+      window.openFolder();
+    });
+
+    await page.waitForTimeout(1500);
+
+    // Now editor should be editable
+    const isReadOnlyAfter = await page.evaluate(() => window.appState?.isReadOnly);
+    expect(isReadOnlyAfter).toBe(false);
+
+    // Verify autosave is re-enabled
+    const autosaveEnabled = await page.evaluate(() => window.appState?.isAutosaveEnabled());
+    expect(autosaveEnabled).toBe(true);
+
+    // Verify autosave checkbox is re-enabled and checked
+    const autosaveCheckbox = await page.locator('#autosave-checkbox');
+    expect(await autosaveCheckbox.isDisabled()).toBe(false);
+    expect(await autosaveCheckbox.isChecked()).toBe(true);
+  });
+
+  test('should restore Related Files section when exiting GitHub mode', async ({ page }) => {
+    // Load GitHub file
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Verify Related Files is hidden in GitHub mode
+    const suggestedLinks = await page.locator('#suggested-links');
+    if ((await suggestedLinks.count()) > 0) {
+      const displayStyle = await suggestedLinks.evaluate((el) => el.style.display);
+      expect(displayStyle).toBe('none');
+    }
+
+    // Mock file system and exit GitHub mode
+    await page.evaluate(() => {
+      window.FileSystemAdapter = {
+        openDirectory: async () => ({
+          name: 'test-workspace',
+          kind: 'directory',
+          getDirectoryHandle: async () => null,
+          getFileHandle: async () => null,
+          values: async function* () {},
+        }),
+        listDirectory: async () => [],
+        readFile: async () => '',
+        writeFile: async () => {},
+        saveFilePicker: async () => null,
+      };
+
+      // Directly call openFolder to exit GitHub mode (since button is disabled)
+      window.openFolder();
+    });
+
+    await page.waitForTimeout(1000);
+
+    // Verify Related Files section is visible again
+    const suggestedLinksAfter = await page.locator('#suggested-links');
+    if ((await suggestedLinksAfter.count()) > 0) {
+      const displayStyleAfter = await suggestedLinksAfter.evaluate((el) => el.style.display);
+      expect(displayStyleAfter).not.toBe('none');
+    }
+  });
+});

--- a/tests/e2e/github-reader.spec.js
+++ b/tests/e2e/github-reader.spec.js
@@ -1,0 +1,193 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('GitHub Reader Feature', () => {
+  test('should load markdown file from GitHub raw URL', async ({ page }) => {
+    // Use a public GitHub file for testing
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    // Navigate to hotnote with gitreader parameter
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+
+    // Wait for loading overlay to appear and disappear
+    await page.waitForSelector('#github-loading-overlay', { timeout: 5000 }).catch(() => {});
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+
+    // Wait for editor to be initialized
+    await page.waitForSelector('#editor', { timeout: 10000 });
+
+    // Wait a bit for content to load
+    await page.waitForTimeout(1000);
+
+    // Check that content is loaded (markdown should contain anthropic)
+    const editorContent = await page.textContent('#editor');
+    expect(editorContent).toContain('Anthropic');
+
+    // Verify filename is set correctly
+    const titleElement = await page.textContent('title');
+    expect(titleElement).toContain('README.md');
+  });
+
+  test('should be in readonly mode', async ({ page }) => {
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    // Check that autosave is disabled in appState
+    const autosaveEnabled = await page.evaluate(() => window.appState?.isAutosaveEnabled());
+    expect(autosaveEnabled).toBe(false);
+
+    // Check that autosave checkbox is disabled
+    const autosaveCheckbox = await page.locator('#autosave-checkbox');
+    expect(await autosaveCheckbox.isDisabled()).toBe(true);
+    expect(await autosaveCheckbox.isChecked()).toBe(false);
+
+    // Check that editor has readonly class or attribute
+    const editorContainer = await page.locator('#editor');
+    const hasReadonlyClass = await editorContainer.evaluate((el) => {
+      return (
+        el.classList.contains('readonly-editor') ||
+        el.querySelector('[contenteditable="false"]') !== null
+      );
+    });
+    expect(hasReadonlyClass).toBe(true);
+  });
+
+  test('should display TOC for markdown with headings', async ({ page }) => {
+    // Use a markdown file with clear headings
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Click file picker button to open it
+    const filePickerBtn = await page.locator('#file-picker-btn');
+    if (await filePickerBtn.isVisible()) {
+      await filePickerBtn.click();
+      await page.waitForTimeout(500);
+
+      // Check that TOC is visible (should show headings)
+      const toc = await page.locator('.toc-list, #toc, [class*="toc"]');
+      if ((await toc.count()) > 0) {
+        const tocVisible = await toc.first().isVisible();
+        // TOC should be present when file picker is open
+        expect(tocVisible).toBe(true);
+      }
+    }
+  });
+
+  test('should handle github.com blob URLs', async ({ page }) => {
+    // Test with github.com blob URL format
+    const githubUrl = 'https://github.com/anthropics/anthropic-sdk-python/blob/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Check that content is loaded
+    const editorContent = await page.textContent('#editor');
+    expect(editorContent).toContain('Anthropic');
+  });
+
+  test('should show error for invalid GitHub URL', async ({ page }) => {
+    const invalidUrl = 'https://raw.githubusercontent.com/invalid/repo/main/notfound.md';
+    const encodedUrl = encodeURIComponent(invalidUrl);
+
+    // Listen for alert dialog
+    page.once('dialog', async (dialog) => {
+      expect(dialog.message()).toContain('Failed to load file from GitHub');
+      await dialog.accept();
+    });
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForTimeout(2000);
+  });
+
+  test('should not show related files section in barebones mode', async ({ page }) => {
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    // Open file picker
+    const filePickerBtn = await page.locator('#file-picker-btn');
+    if (await filePickerBtn.isVisible()) {
+      await filePickerBtn.click();
+      await page.waitForTimeout(500);
+
+      // Related files section should not show folder navigation
+      // (barebones version doesn't implement this)
+      // In barebones mode, we just verify the app loads correctly
+      // Full folder navigation is not implemented in this version
+    }
+  });
+
+  test('should preserve gitreader parameter in URL', async ({ page }) => {
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(1000);
+
+    // Check that URL still contains gitreader parameter
+    const currentUrl = page.url();
+    expect(currentUrl).toContain('gitreader=');
+  });
+
+  test('should handle markdown files with code blocks', async ({ page }) => {
+    const githubUrl =
+      'https://raw.githubusercontent.com/anthropics/anthropic-sdk-python/main/README.md';
+    const encodedUrl = encodeURIComponent(githubUrl);
+
+    await page.goto(`/?gitreader=${encodedUrl}`);
+    await page
+      .waitForSelector('#github-loading-overlay', { state: 'hidden', timeout: 10000 })
+      .catch(() => {});
+    await page.waitForSelector('#editor', { timeout: 10000 });
+    await page.waitForTimeout(2000);
+
+    // Content should be rendered (code blocks should be visible)
+    const editorContent = await page.textContent('#editor');
+    expect(editorContent.length).toBeGreaterThan(100);
+  });
+});

--- a/tests/github-adapter.test.js
+++ b/tests/github-adapter.test.js
@@ -1,0 +1,248 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { GitHubAdapter } from '../src/fs/github-adapter.js';
+
+describe('GitHubAdapter', () => {
+  describe('parseURL', () => {
+    it('should parse raw.githubusercontent.com URLs', () => {
+      const url = 'https://raw.githubusercontent.com/zombar/hotnote/main/README.md';
+      const result = GitHubAdapter.parseURL(url);
+
+      expect(result).toEqual({
+        owner: 'zombar',
+        repo: 'hotnote',
+        branch: 'main',
+        path: 'README.md',
+      });
+    });
+
+    it('should parse raw.githubusercontent.com URLs with nested paths', () => {
+      const url = 'https://raw.githubusercontent.com/owner/repo/main/docs/guide/intro.md';
+      const result = GitHubAdapter.parseURL(url);
+
+      expect(result).toEqual({
+        owner: 'owner',
+        repo: 'repo',
+        branch: 'main',
+        path: 'docs/guide/intro.md',
+      });
+    });
+
+    it('should parse github.com blob URLs', () => {
+      const url = 'https://github.com/zombar/hotnote/blob/main/README.md';
+      const result = GitHubAdapter.parseURL(url);
+
+      expect(result).toEqual({
+        owner: 'zombar',
+        repo: 'hotnote',
+        branch: 'main',
+        path: 'README.md',
+      });
+    });
+
+    it('should throw error for invalid URLs', () => {
+      expect(() => GitHubAdapter.parseURL('https://invalid.com/file.md')).toThrow(
+        'Invalid GitHub URL format'
+      );
+    });
+
+    it('should throw error for malformed GitHub URLs', () => {
+      expect(() => GitHubAdapter.parseURL('https://github.com/owner')).toThrow(
+        'Invalid GitHub URL format'
+      );
+    });
+  });
+
+  describe('constructor', () => {
+    it('should create instance with parsed URL data', () => {
+      const adapter = new GitHubAdapter('owner', 'repo', 'main');
+
+      expect(adapter.owner).toBe('owner');
+      expect(adapter.repo).toBe('repo');
+      expect(adapter.branch).toBe('main');
+    });
+
+    it('should default to main branch if not specified', () => {
+      const adapter = new GitHubAdapter('owner', 'repo');
+
+      expect(adapter.branch).toBe('main');
+    });
+  });
+
+  describe('readFile', () => {
+    let adapter;
+    let fetchMock;
+
+    beforeEach(() => {
+      adapter = new GitHubAdapter('owner', 'repo', 'main');
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    it('should fetch file content from raw.githubusercontent.com', async () => {
+      const mockContent = '# Hello World';
+      fetchMock.mockResolvedValue({
+        ok: true,
+        text: async () => mockContent,
+      });
+
+      const content = await adapter.readFile('README.md');
+
+      expect(content).toBe(mockContent);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://raw.githubusercontent.com/owner/repo/main/README.md'
+      );
+    });
+
+    it('should throw error for failed fetch', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(adapter.readFile('missing.md')).rejects.toThrow('HTTP 404: Not Found');
+    });
+
+    it('should handle network errors', async () => {
+      fetchMock.mockRejectedValue(new Error('Network error'));
+
+      await expect(adapter.readFile('README.md')).rejects.toThrow('Network error');
+    });
+  });
+
+  describe('listDirectory', () => {
+    let adapter;
+    let fetchMock;
+
+    beforeEach(() => {
+      adapter = new GitHubAdapter('owner', 'repo', 'main');
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    it('should list directory contents via GitHub API', async () => {
+      const mockResponse = [
+        {
+          name: 'README.md',
+          type: 'file',
+          size: 1234,
+          path: 'README.md',
+          download_url: 'https://raw.githubusercontent.com/owner/repo/main/README.md',
+        },
+        {
+          name: 'src',
+          type: 'dir',
+          size: 0,
+          path: 'src',
+          download_url: null,
+        },
+      ];
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const items = await adapter.listDirectory('');
+
+      expect(items).toHaveLength(2);
+      expect(items[0]).toMatchObject({
+        name: 'README.md',
+        type: 'file',
+        path: 'README.md',
+      });
+      expect(items[1]).toMatchObject({
+        name: 'src',
+        type: 'dir',
+        path: 'src',
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/contents/?ref=main'
+      );
+    });
+
+    it('should list nested directory contents', async () => {
+      const mockResponse = [
+        {
+          name: 'index.js',
+          type: 'file',
+          size: 500,
+          path: 'src/index.js',
+          download_url: 'https://raw.githubusercontent.com/owner/repo/main/src/index.js',
+        },
+      ];
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const items = await adapter.listDirectory('src');
+
+      expect(items).toHaveLength(1);
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/contents/src?ref=main'
+      );
+    });
+
+    it('should throw error for failed API call', async () => {
+      fetchMock.mockResolvedValue({
+        ok: false,
+        status: 404,
+        statusText: 'Not Found',
+      });
+
+      await expect(adapter.listDirectory('invalid')).rejects.toThrow('HTTP 404: Not Found');
+    });
+  });
+
+  describe('getMetadata', () => {
+    let adapter;
+    let fetchMock;
+
+    beforeEach(() => {
+      adapter = new GitHubAdapter('owner', 'repo', 'main');
+      fetchMock = vi.fn();
+      global.fetch = fetchMock;
+    });
+
+    it('should fetch file metadata from GitHub API', async () => {
+      const mockResponse = {
+        name: 'README.md',
+        size: 1234,
+        sha: 'abc123',
+      };
+
+      fetchMock.mockResolvedValue({
+        ok: true,
+        json: async () => mockResponse,
+      });
+
+      const metadata = await adapter.getMetadata('README.md');
+
+      expect(metadata).toMatchObject({
+        size: 1234,
+        sha: 'abc123',
+      });
+      expect(fetchMock).toHaveBeenCalledWith(
+        'https://api.github.com/repos/owner/repo/contents/README.md?ref=main'
+      );
+    });
+  });
+
+  describe('URL validation', () => {
+    it('should validate whitelisted GitHub domains', () => {
+      expect(() =>
+        GitHubAdapter.parseURL('https://raw.githubusercontent.com/a/b/c/d.md')
+      ).not.toThrow();
+
+      expect(() => GitHubAdapter.parseURL('https://github.com/a/b/blob/c/d.md')).not.toThrow();
+    });
+
+    it('should reject non-GitHub URLs', () => {
+      expect(() => GitHubAdapter.parseURL('https://evil.com/fake/path')).toThrow(
+        'Invalid GitHub URL format'
+      );
+    });
+  });
+});

--- a/tests/navigation/url-param-manager-gitreader.test.js
+++ b/tests/navigation/url-param-manager-gitreader.test.js
@@ -1,0 +1,240 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { URLParamManager } from '../../src/navigation/url-param-manager.js';
+
+/**
+ * Unit tests for URLParamManager - GitHub Reader support
+ * Tests gitreader URL parameter handling
+ */
+describe('URLParamManager - GitHub Reader', () => {
+  let originalLocation;
+  let originalHistory;
+
+  beforeEach(() => {
+    // Save original location and history
+    originalLocation = window.location;
+    originalHistory = window.history;
+
+    // Mock window.location
+    delete window.location;
+    window.location = {
+      search: '',
+      href: 'http://localhost:3000/',
+      origin: 'http://localhost:3000',
+      pathname: '/',
+    };
+
+    // Mock window.history
+    window.history = {
+      replaceState: vi.fn(),
+      pushState: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    // Restore original location and history
+    window.location = originalLocation;
+    window.history = originalHistory;
+  });
+
+  describe('getGitReader()', () => {
+    it('should return null when no gitreader param exists', () => {
+      window.location.search = '';
+
+      const result = URLParamManager.getGitReader();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return gitreader URL for raw.githubusercontent.com', () => {
+      const githubUrl = 'https://raw.githubusercontent.com/zombar/hotnote/main/README.md';
+      window.location.search = `?gitreader=${encodeURIComponent(githubUrl)}`;
+
+      const result = URLParamManager.getGitReader();
+
+      expect(result).toBe(githubUrl);
+    });
+
+    it('should return gitreader URL for github.com blob', () => {
+      const githubUrl = 'https://github.com/zombar/hotnote/blob/main/README.md';
+      window.location.search = `?gitreader=${encodeURIComponent(githubUrl)}`;
+
+      const result = URLParamManager.getGitReader();
+
+      expect(result).toBe(githubUrl);
+    });
+
+    it('should return null for empty gitreader param', () => {
+      window.location.search = '?gitreader=';
+
+      const result = URLParamManager.getGitReader();
+
+      expect(result).toBeNull();
+    });
+
+    it('should handle nested path URLs', () => {
+      const githubUrl = 'https://raw.githubusercontent.com/owner/repo/branch/docs/guide/intro.md';
+      window.location.search = `?gitreader=${encodeURIComponent(githubUrl)}`;
+
+      const result = URLParamManager.getGitReader();
+
+      expect(result).toBe(githubUrl);
+    });
+  });
+
+  describe('hasGitReader()', () => {
+    it('should return false when no gitreader param exists', () => {
+      window.location.search = '';
+
+      expect(URLParamManager.hasGitReader()).toBe(false);
+    });
+
+    it('should return true when gitreader param exists with value', () => {
+      window.location.search = '?gitreader=https://raw.githubusercontent.com/a/b/c/d.md';
+
+      expect(URLParamManager.hasGitReader()).toBe(true);
+    });
+
+    it('should return false when gitreader param is empty', () => {
+      window.location.search = '?gitreader=';
+
+      expect(URLParamManager.hasGitReader()).toBe(false);
+    });
+  });
+
+  describe('setGitReader()', () => {
+    it('should set gitreader parameter', () => {
+      const githubUrl = 'https://raw.githubusercontent.com/zombar/hotnote/main/README.md';
+
+      URLParamManager.setGitReader(githubUrl);
+
+      expect(window.history.replaceState).toHaveBeenCalledWith(
+        null,
+        '',
+        expect.stringContaining('gitreader=')
+      );
+    });
+
+    it('should encode gitreader URL properly', () => {
+      const githubUrl = 'https://raw.githubusercontent.com/owner/repo/main/file with spaces.md';
+
+      URLParamManager.setGitReader(githubUrl);
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).toContain('gitreader=');
+      // URL should be encoded (URLSearchParams encodes spaces as + which is valid)
+      expect(newUrl).toMatch(/file[\+%20]with[\+%20]spaces\.md/);
+    });
+
+    it('should clear gitreader parameter when passed null', () => {
+      window.location.search = '?gitreader=https://example.com/file.md';
+
+      URLParamManager.setGitReader(null);
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).not.toContain('gitreader');
+    });
+
+    it('should clear gitreader parameter when passed empty string', () => {
+      window.location.search = '?gitreader=https://example.com/file.md';
+
+      URLParamManager.setGitReader('');
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).not.toContain('gitreader');
+    });
+
+    it('should preserve other query parameters when setting gitreader', () => {
+      window.location.search = '?foo=bar&baz=qux';
+      window.location.href = 'http://localhost:3000/?foo=bar&baz=qux';
+
+      URLParamManager.setGitReader('https://example.com/file.md');
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).toContain('gitreader=');
+      expect(newUrl).toContain('foo=bar');
+      expect(newUrl).toContain('baz=qux');
+    });
+  });
+
+  describe('clearGitReader()', () => {
+    it('should clear gitreader parameter', () => {
+      window.location.search = '?gitreader=https://example.com/file.md';
+      window.location.href = 'http://localhost:3000/?gitreader=https://example.com/file.md';
+
+      URLParamManager.clearGitReader();
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).not.toContain('gitreader');
+    });
+
+    it('should preserve other query parameters when clearing gitreader', () => {
+      window.location.search = '?gitreader=https://example.com/file.md&foo=bar';
+      window.location.href = 'http://localhost:3000/?gitreader=https://example.com/file.md&foo=bar';
+
+      URLParamManager.clearGitReader();
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).not.toContain('gitreader');
+      expect(newUrl).toContain('foo=bar');
+    });
+
+    it('should handle clearing when no gitreader exists', () => {
+      window.location.search = '?foo=bar';
+      window.location.href = 'http://localhost:3000/?foo=bar';
+
+      URLParamManager.clearGitReader();
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).not.toContain('gitreader');
+      expect(newUrl).toContain('foo=bar');
+    });
+  });
+
+  describe('gitreader and workdir independence', () => {
+    it('should allow gitreader and workdir to coexist', () => {
+      window.location.search = '?workdir=/path&gitreader=https://example.com/file.md';
+      window.location.href =
+        'http://localhost:3000/?workdir=/path&gitreader=https://example.com/file.md';
+
+      const workdir = URLParamManager.getWorkdir();
+      const gitreader = URLParamManager.getGitReader();
+
+      expect(workdir).toBe('/path');
+      expect(gitreader).toBe('https://example.com/file.md');
+    });
+
+    it('should not affect workdir/file when setting gitreader', () => {
+      window.location.search = '?workdir=/path&file=test.md';
+      window.location.href = 'http://localhost:3000/?workdir=/path&file=test.md';
+
+      URLParamManager.setGitReader('https://example.com/file.md');
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      // workdir may be encoded as %2F or / depending on URLSearchParams implementation
+      expect(newUrl).toMatch(/workdir=(%2F|\/)path/);
+      expect(newUrl).toContain('file=test.md');
+      expect(newUrl).toContain('gitreader=');
+    });
+
+    it('should not affect gitreader when updating workdir/file', () => {
+      window.location.search = '?gitreader=https://example.com/file.md';
+      window.location.href = 'http://localhost:3000/?gitreader=https://example.com/file.md';
+
+      URLParamManager.update('/new/path', 'newfile.md');
+
+      const call = window.history.replaceState.mock.calls[0];
+      const newUrl = call[2];
+      expect(newUrl).toContain('gitreader=');
+      expect(newUrl).toContain('workdir=/new/path');
+      expect(newUrl).toContain('file=newfile.md');
+    });
+  });
+});


### PR DESCRIPTION
GitHub Reader improvements:
- Add changelog link to version update banner with gitreader parameter
- Replace loading overlay with subtle blur effect
- Add toast notification "Viewing in read-only mode"
- Disable autosave checkbox in reader mode (re-enable on exit)
- Disable "new" button in reader mode

Rich text editor improvements:
- Reduce top padding from 4rem to 2rem (50% reduction)
- Fix bottom padding visibility by removing nested scroll containers
- Change .milkdown from height:100% to min-height:100%
- Remove overflow:auto from .milkdown (let parent #editor handle scrolling)

Test updates:
- Add test for changelog link in version banner
- Remove unused variable in github-reader.spec.js

🤖 Generated with [Claude Code](https://claude.com/claude-code)